### PR TITLE
Remove MAINTAINER in RHEL image

### DIFF
--- a/2.7/Dockerfile.rhel7
+++ b/2.7/Dockerfile.rhel7
@@ -3,8 +3,6 @@ FROM openshift/base-rhel7
 # This image provides a Python 2.7 environment you can use to run your Python
 # applications.
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 ENV PYTHON_VERSION=2.7 \

--- a/3.3/Dockerfile.rhel7
+++ b/3.3/Dockerfile.rhel7
@@ -3,8 +3,6 @@ FROM openshift/base-rhel7
 # This image provides a Python 3.3 environment you can use to run your Python
 # applications.
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 ENV PYTHON_VERSION=3.3 \

--- a/3.4/Dockerfile.rhel7
+++ b/3.4/Dockerfile.rhel7
@@ -3,8 +3,6 @@ FROM openshift/base-rhel7
 # This image provides a Python 3.4 environment you can use to run your Python
 # applications.
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 ENV PYTHON_VERSION=3.4 \


### PR DESCRIPTION
It is recommended not to use MAINTAINER in RHEL images.