### PR TITLE
move newer image into centos/rhscl namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,7 @@
-SKIP_SQUASH?=0
-VERSIONS="2.7 3.3 3.4"
+# Variables are documented in hack/build.sh.
+BASE_IMAGE_NAME = python
+VERSIONS = 2.7 3.3 3.4
+OPENSHIFT_NAMESPACES = 3.3
 
-ifeq ($(TARGET),rhel7)
-	OS := rhel7
-else
-	OS := centos7
-endif
-
-ifeq ($(VERSION), 2.7)
-	VERSION := 2.7
-else ifeq ($(VERSION), 3.3)
-	VERSION := 3.3
-else ifeq ($(VERSION), 3.4)
-	VERSION := 3.4
-else
-	VERSION :=
-endif
-
-.PHONY: build
-build:
-	SKIP_SQUASH=$(SKIP_SQUASH) VERSIONS=$(VERSIONS) hack/build.sh $(OS) $(VERSION)
-
-.PHONY: test
-test:
-	SKIP_SQUASH=$(SKIP_SQUASH) VERSIONS=$(VERSIONS) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_MODE=true hack/build.sh $(OS) $(VERSION)
+# Include common Makefile code.
+include hack/common.mk

--- a/hack/common.mk
+++ b/hack/common.mk
@@ -1,0 +1,25 @@
+SKIP_SQUASH?=0
+
+build = hack/build.sh
+
+ifeq ($(TARGET),rhel7)
+	OS := rhel7
+else
+	OS := centos7
+endif
+
+script_env = \
+	SKIP_SQUASH=$(SKIP_SQUASH)                      \
+	VERSIONS="$(VERSIONS)"                          \
+	OS=$(OS)                                        \
+	VERSION=$(VERSION)                              \
+	BASE_IMAGE_NAME=$(BASE_IMAGE_NAME)              \
+	OPENSHIFT_NAMESPACES="$(OPENSHIFT_NAMESPACES)"
+
+.PHONY: build
+build:
+	$(script_env) $(build)
+
+.PHONY: test
+test:
+	$(script_env) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_MODE=true $(build)


### PR DESCRIPTION
While we are on it, also unify the build scripts among images'
repositories:

- hack/ directory should be _just_ mirrored
- Makefile should be as declarative as possible
- build.sh should not rely on repository name