### PR TITLE
Include httpd and httpd-devel in the builder image

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -15,7 +15,7 @@ LABEL io.k8s.description="Platform for building and running Python 2.7 applicati
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,python,python27,rh-python27"
 
-RUN INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip epel-release nss_wrapper" && \
+RUN INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip epel-release nss_wrapper httpd httpd-devel" && \
     yum install -y centos-release-scl && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/2.7/Dockerfile.rhel7
+++ b/2.7/Dockerfile.rhel7
@@ -23,7 +23,7 @@ LABEL Name="rhscl/python-27-rhel7" \
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip nss_wrapper" && \
+    INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip nss_wrapper httpd httpd-devel" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && rpm -V $INSTALL_PKGS && \
     yum clean all -y
 

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -15,7 +15,7 @@ LABEL io.k8s.description="Platform for building and running Python 3.3 applicati
       io.openshift.tags="builder,python,python33"
 
 RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools epel-release nss_wrapper" && \
+    INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools epel-release nss_wrapper httpd httpd-devel" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y

--- a/3.3/Dockerfile.rhel7
+++ b/3.3/Dockerfile.rhel7
@@ -23,7 +23,7 @@ LABEL BZComponent="openshift-sti-python-docker" \
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools python33-python-pip nss_wrapper" && \
+    INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools python33-python-pip nss_wrapper httpd httpd-devel" && \
     yum install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -16,7 +16,7 @@ LABEL io.k8s.description="Platform for building and running Python 3.4 applicati
       io.openshift.tags="builder,python,python34,rh-python34"
 
 RUN yum install --enablerepo=centosplus -y centos-release-scl epel-release && \
-    INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip nss_wrapper" && \
+    INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip nss_wrapper httpd httpd-devel" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y

--- a/3.4/Dockerfile.rhel7
+++ b/3.4/Dockerfile.rhel7
@@ -23,7 +23,7 @@ LABEL Name="rhscl/python-34-rhel7" \
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip nss_wrapper" && \
+    INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip nss_wrapper httpd httpd-devel" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y


### PR DESCRIPTION
This supports using mod_wsgi-express instead of gunicorn in images built with the S2I Python builder.

Closes #59.