### PR TITLE
Remove *-logos to reduce image sizes

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -15,8 +15,8 @@ LABEL io.k8s.description="Platform for building and running Python 2.7 applicati
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,python,python27,rh-python27"
 
-RUN INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip epel-release nss_wrapper httpd httpd-devel" && \
-    yum install -y centos-release-scl && \
+RUN yum install -y centos-release-scl && \
+    INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip epel-release nss_wrapper httpd httpd-devel" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y
@@ -28,6 +28,9 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # run and build the applications.
 COPY ./contrib/ /opt/app-root
 
+# In order to drop the root user, we have to make some directories world
+# writable as OpenShift default security model is to run the container under
+# random UID.
 RUN chown -R 1001:0 /opt/app-root && chmod -R og+rwx /opt/app-root
 
 USER 1001

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -19,6 +19,8 @@ RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip epel-release nss_wrapper httpd httpd-devel" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image size smaller
+    rpm -e --nodeps centos-logos && \
     yum clean all -y
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/2.7/Dockerfile.rhel7
+++ b/2.7/Dockerfile.rhel7
@@ -26,6 +26,8 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip nss_wrapper httpd httpd-devel" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    # Remove redhat-logos (httpd dependency) to keep image size smaller
+    rpm -e --nodeps redhat-logos && \
     yum clean all -y
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/2.7/Dockerfile.rhel7
+++ b/2.7/Dockerfile.rhel7
@@ -24,7 +24,8 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip nss_wrapper httpd httpd-devel" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && rpm -V $INSTALL_PKGS && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
     yum clean all -y
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
@@ -35,7 +36,7 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 COPY ./contrib/ /opt/app-root
 
 # In order to drop the root user, we have to make some directories world
-# writeable as OpenShift default security model is to run the container under
+# writable as OpenShift default security model is to run the container under
 # random UID.
 RUN chown -R 1001:0 /opt/app-root && chmod -R og+rwx /opt/app-root
 

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -19,6 +19,8 @@ RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools epel-release nss_wrapper httpd httpd-devel" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image size smaller
+    rpm -e --nodeps centos-logos && \
     yum clean all -y
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -2,6 +2,7 @@ FROM openshift/base-centos7
 
 # This image provides a Python 3.3 environment you can use to run your Python
 # applications.
+
 MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
 
 EXPOSE 8080
@@ -27,6 +28,9 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # run and build the applications.
 COPY ./contrib/ /opt/app-root
 
+# In order to drop the root user, we have to make some directories world
+# writable as OpenShift default security model is to run the container under
+# random UID.
 RUN scl enable python33 "easy_install pip==1.5.6" && \
     chown -R 1001:0 /opt/app-root && chmod -R og+rwx /opt/app-root
 

--- a/3.3/Dockerfile.rhel7
+++ b/3.3/Dockerfile.rhel7
@@ -26,6 +26,8 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools python33-python-pip nss_wrapper httpd httpd-devel" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    # Remove redhat-logos (httpd dependency) to keep image size smaller
+    rpm -e --nodeps redhat-logos && \
     yum clean all -y
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/3.3/Dockerfile.rhel7
+++ b/3.3/Dockerfile.rhel7
@@ -24,7 +24,7 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools python33-python-pip nss_wrapper httpd httpd-devel" && \
-    yum install -y --setopt=tsflags=nodocs  $INSTALL_PKGS && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y
 
@@ -36,7 +36,7 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 COPY ./contrib/ /opt/app-root
 
 # In order to drop the root user, we have to make some directories world
-# writeable as OpenShift default security model is to run the container under
+# writable as OpenShift default security model is to run the container under
 # random UID.
 RUN chown -R 1001:0 /opt/app-root && chmod -R og+rwx /opt/app-root
 

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -19,6 +19,8 @@ RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip epel-release nss_wrapper httpd httpd-devel" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image size smaller
+    rpm -e --nodeps centos-logos && \
     yum clean all -y
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -15,8 +15,8 @@ LABEL io.k8s.description="Platform for building and running Python 3.4 applicati
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,python,python34,rh-python34"
 
-RUN yum install --enablerepo=centosplus -y centos-release-scl epel-release && \
-    INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip nss_wrapper httpd httpd-devel" && \
+RUN yum install -y centos-release-scl && \
+    INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip epel-release nss_wrapper httpd httpd-devel" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y
@@ -28,6 +28,9 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # run and build the applications.
 COPY ./contrib/ /opt/app-root
 
+# In order to drop the root user, we have to make some directories world
+# writable as OpenShift default security model is to run the container under
+# random UID.
 RUN chown -R 1001:0 /opt/app-root && chmod -R og+rwx /opt/app-root
 
 USER 1001

--- a/3.4/Dockerfile.rhel7
+++ b/3.4/Dockerfile.rhel7
@@ -26,6 +26,8 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip nss_wrapper httpd httpd-devel" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    # Remove redhat-logos (httpd dependency) to keep image size smaller
+    rpm -e --nodeps redhat-logos && \
     yum clean all -y
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/3.4/Dockerfile.rhel7
+++ b/3.4/Dockerfile.rhel7
@@ -36,7 +36,7 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 COPY ./contrib/ /opt/app-root
 
 # In order to drop the root user, we have to make some directories world
-# writeable as OpenShift default security model is to run the container under
+# writable as OpenShift default security model is to run the container under
 # random UID.
 RUN chown -R 1001:0 /opt/app-root && chmod -R og+rwx /opt/app-root
 


### PR DESCRIPTION
Adding httpd as a dependency brought in ~80MB, ~20 of those from `centos-logos` package, which is liked used to show a logo in the default index page.

This is a follow up to #97 aiming to reduce image sizes, while keeping httpd and httpd-devel in.

As a bonus, the first commit is removing some asymmetries that make comparing the files harder, and makes it harder to automate changing the Dockerfiles for a single Python version and applying the patch to the others.

----------------------------

For the record, here's the trick to avoid copy-paste:

```console
$ git diff -U2 2.7 | sed 's/2.7/3.3/' | git apply -
$ git diff -U2 2.7 | sed 's/2.7/3.4/' | git apply -
```

Normally, `-U2` is not needed, but I had to use it here to ignore part of the context that wouldn't allow for a clean patch (`-U2` means use only 2 lines of diff context instead of the default 3).