### PR TITLE
Added libjpeg

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -16,7 +16,7 @@ LABEL io.k8s.description="Platform for building and running Python 2.7 applicati
       io.openshift.tags="builder,python,python27,rh-python27"
 
 RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip epel-release nss_wrapper httpd httpd-devel" && \
+    INSTALL_PKGS="libjpeg-devel python27 python27-python-devel python27-python-setuptools python27-python-pip epel-release nss_wrapper httpd httpd-devel" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image size smaller


### PR DESCRIPTION
All of my django projects depend on pillow and libjpeg. 
This is a minimal impact for image size
Installed size: 656 k