### PR TITLE
Replace .sti -> .s2i in README.md

### DIFF
--- a/2.7/README.md
+++ b/2.7/README.md
@@ -89,8 +89,8 @@ Repository organization
 Environment variables
 ---------------------
 
-To set these environment variables, you can place them as a key value pair into a `.sti/environment`
-file inside your source code repository.
+To set these environment variables, you can place them as a key value pair into
+a `.s2i/environment` file inside your source code repository.
 
 * **APP_FILE**
 


### PR DESCRIPTION
@bparees @soltysh are we ready to point users to use `.s2i` instead of the deprecated `.sti`? I guess so. PTAL.

Fixes #106.